### PR TITLE
cli: fix user agent set

### DIFF
--- a/cli/cmd/set.go
+++ b/cli/cmd/set.go
@@ -154,7 +154,6 @@ func newSetConf(cCtx *cli.Context) (*setConf, error) {
 		conf.dm, _ = ddflare.NewDNSManager(ddflare.DDNS)
 		conf.dm.SetApiEndpoint(svc)
 	}
-	conf.dm.SetUserAgent(USERAGENT + version.Version)
 	token := cCtx.String("api-token")
 	if token == "" {
 		user := cCtx.String("user")
@@ -167,6 +166,8 @@ func newSetConf(cCtx *cli.Context) (*setConf, error) {
 	if err := conf.dm.Init(token); err != nil {
 		return nil, errors.New("DNS Manager auth initialization failed")
 	}
+
+	conf.dm.SetUserAgent(USERAGENT + version.Version)
 
 	conf.address = cCtx.String("address")
 	if conf.address == "" {


### PR DESCRIPTION
The user agent was set before the DNSManager structure was properly initialized.
Move the user agent set after the DNSManager init.

Fixes: #13a3c7823b8366f20c325b9ddbe241e79591a3e8