### PR TITLE
Improve test coverage

### DIFF
--- a/pkg/cflare/cflare.go
+++ b/pkg/cflare/cflare.go
@@ -118,7 +118,7 @@ func (c *Cloudflare) Update(fqdn, ip string) error {
 
 func getZone(fqdn string) (string, error) {
 	domain := strings.Split(fqdn, ".")
-	if len(domain) < 2 {
+	if len(domain) < 2 || domain[len(domain)-2] == "" || domain[len(domain)-1] == "" {
 		return "", fmt.Errorf("%q is not a valid dns name", fqdn)
 	}
 	zone := domain[len(domain)-2] + "." + domain[len(domain)-1]

--- a/pkg/cflare/cflare_test.go
+++ b/pkg/cflare/cflare_test.go
@@ -17,7 +17,12 @@ limitations under the License.
 package cflare
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
+
+	cf "github.com/cloudflare/cloudflare-go"
 )
 
 func TestNew(t *testing.T) {
@@ -48,6 +53,323 @@ func TestNew(t *testing.T) {
 			}
 			if cflare.api.APIToken != tt.token {
 				t.Fatalf("expected token %q but got %q", tt.token, cflare.api.APIToken)
+			}
+		})
+	}
+}
+
+func TestCloudflare_GetSetApiEndpoint(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	err := c.Init("test-token")
+	if err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	// Test default endpoint
+	defaultEndpoint := c.GetApiEndpoint()
+	if defaultEndpoint == "" {
+		t.Error("Expected non-empty default API endpoint")
+	}
+
+	// Test setting custom endpoint
+	customEndpoint := "https://custom.api.endpoint.com"
+	c.SetApiEndpoint(customEndpoint)
+
+	if got := c.GetApiEndpoint(); got != customEndpoint {
+		t.Errorf("Expected API endpoint %q, got %q", customEndpoint, got)
+	}
+}
+
+func TestCloudflare_GetSetUserAgent(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	err := c.Init("test-token")
+	if err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	// Test default user agent
+	defaultUA := c.GetUserAgent()
+	if defaultUA == "" {
+		t.Error("Expected non-empty default user agent")
+	}
+
+	// Test setting custom user agent
+	customUA := "CustomApp/1.0"
+	c.SetUserAgent(customUA)
+
+	if got := c.GetUserAgent(); got != customUA {
+		t.Errorf("Expected user agent %q, got %q", customUA, got)
+	}
+}
+
+func TestCloudflare_InitError(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+
+	// Test uninitialized state
+	if c.api != nil {
+		t.Error("Expected api to be nil before initialization")
+	}
+}
+
+func TestCloudflare_Resolve(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+
+	tests := map[string]struct {
+		fqdn        string
+		expectError bool
+	}{
+		"valid_domain":   {"google.com", false},
+		"invalid_domain": {"this-domain-should-not-exist-12345.invalid", true},
+		"empty_domain":   {"", true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ip, err := c.Resolve(tt.fqdn)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for FQDN %q, but got IP %q", tt.fqdn, ip)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for FQDN %q: %v", tt.fqdn, err)
+				}
+				if ip == "" {
+					t.Errorf("Expected non-empty IP for FQDN %q", tt.fqdn)
+				}
+			}
+		})
+	}
+}
+
+func TestCloudflare_UpdateUnitialized(t *testing.T) {
+	t.Parallel()
+
+	c := New()
+	// Don't initialize the API
+
+	err := c.Update("test.example.com", "192.168.1.1")
+	if err == nil {
+		t.Error("Expected error when API is not initialized")
+	}
+
+	expectedMsg := "not authorized"
+	if err.Error() != expectedMsg {
+		t.Errorf("Expected error message %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+func TestGetZone(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		fqdn         string
+		expectedZone string
+		expectError  bool
+	}{
+		"subdomain":      {"sub.example.com", "example.com", false},
+		"domain":         {"example.com", "example.com", false},
+		"deep_subdomain": {"a.b.c.example.com", "example.com", false},
+		"single_word":    {"localhost", "", true},
+		"empty":          {"", "", true},
+		"single_dot":     {".", "", true},
+		"co_uk_domain":   {"test.example.co.uk", "co.uk", false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			zone, err := getZone(tt.fqdn)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for FQDN %q, but got zone %q", tt.fqdn, zone)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for FQDN %q: %v", tt.fqdn, err)
+				}
+				if zone != tt.expectedZone {
+					t.Errorf("Expected zone %q for FQDN %q, got %q", tt.expectedZone, tt.fqdn, zone)
+				}
+			}
+		})
+	}
+}
+
+// mockCloudflareAPI is a mock implementation for testing Update method
+type mockCloudflareAPI struct {
+	zoneIDByNameFunc    func(zoneName string) (string, error)
+	listDNSRecordsFunc  func(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error)
+	updateDNSRecordFunc func(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateDNSRecordParams) (cf.DNSRecord, error)
+}
+
+func (m *mockCloudflareAPI) ZoneIDByName(zoneName string) (string, error) {
+	if m.zoneIDByNameFunc != nil {
+		return m.zoneIDByNameFunc(zoneName)
+	}
+	return "", errors.New("mock not implemented")
+}
+
+func (m *mockCloudflareAPI) ListDNSRecords(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error) {
+	if m.listDNSRecordsFunc != nil {
+		return m.listDNSRecordsFunc(ctx, rc, params)
+	}
+	return nil, nil, errors.New("mock not implemented")
+}
+
+func (m *mockCloudflareAPI) UpdateDNSRecord(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateDNSRecordParams) (cf.DNSRecord, error) {
+	if m.updateDNSRecordFunc != nil {
+		return m.updateDNSRecordFunc(ctx, rc, params)
+	}
+	return cf.DNSRecord{}, errors.New("mock not implemented")
+}
+
+func TestCloudflare_UpdateWithMock(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		fqdn                string
+		ip                  string
+		zoneIDByNameFunc    func(string) (string, error)
+		listDNSRecordsFunc  func(context.Context, *cf.ResourceContainer, cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error)
+		updateDNSRecordFunc func(context.Context, *cf.ResourceContainer, cf.UpdateDNSRecordParams) (cf.DNSRecord, error)
+		expectError         bool
+		expectedErrorMsg    string
+	}{
+		"invalid_zone": {
+			fqdn:             "invalid",
+			ip:               "192.168.1.1",
+			expectError:      true,
+			expectedErrorMsg: "cannot identify DNS zone",
+		},
+		"zone_not_found": {
+			fqdn: "test.example.com",
+			ip:   "192.168.1.1",
+			zoneIDByNameFunc: func(zoneName string) (string, error) {
+				return "", errors.New("zone not found")
+			},
+			expectError:      true,
+			expectedErrorMsg: "cannot retrieve DNS zone id",
+		},
+		"list_dns_records_error": {
+			fqdn: "test.example.com",
+			ip:   "192.168.1.1",
+			zoneIDByNameFunc: func(zoneName string) (string, error) {
+				return "zone123", nil
+			},
+			listDNSRecordsFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error) {
+				return nil, nil, errors.New("API error")
+			},
+			expectError:      true,
+			expectedErrorMsg: "API error",
+		},
+		"no_records_found": {
+			fqdn: "test.example.com",
+			ip:   "192.168.1.1",
+			zoneIDByNameFunc: func(zoneName string) (string, error) {
+				return "zone123", nil
+			},
+			listDNSRecordsFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error) {
+				return []cf.DNSRecord{}, nil, nil
+			},
+			expectError:      true,
+			expectedErrorMsg: "found 0 matching records",
+		},
+		"multiple_records_found": {
+			fqdn: "test.example.com",
+			ip:   "192.168.1.1",
+			zoneIDByNameFunc: func(zoneName string) (string, error) {
+				return "zone123", nil
+			},
+			listDNSRecordsFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error) {
+				return []cf.DNSRecord{
+					{ID: "rec1", Name: "test.example.com", Type: "A"},
+					{ID: "rec2", Name: "test.example.com", Type: "A"},
+				}, nil, nil
+			},
+			expectError:      true,
+			expectedErrorMsg: "found 2 matching records",
+		},
+		"update_dns_record_error": {
+			fqdn: "test.example.com",
+			ip:   "192.168.1.1",
+			zoneIDByNameFunc: func(zoneName string) (string, error) {
+				return "zone123", nil
+			},
+			listDNSRecordsFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error) {
+				return []cf.DNSRecord{
+					{ID: "rec1", Name: "test.example.com", Type: "A", Content: "1.2.3.4"},
+				}, nil, nil
+			},
+			updateDNSRecordFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateDNSRecordParams) (cf.DNSRecord, error) {
+				return cf.DNSRecord{}, errors.New("update failed")
+			},
+			expectError:      true,
+			expectedErrorMsg: "update failed",
+		},
+		"successful_update": {
+			fqdn: "test.example.com",
+			ip:   "192.168.1.1",
+			zoneIDByNameFunc: func(zoneName string) (string, error) {
+				return "zone123", nil
+			},
+			listDNSRecordsFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.ListDNSRecordsParams) ([]cf.DNSRecord, *cf.ResultInfo, error) {
+				return []cf.DNSRecord{
+					{
+						ID:      "rec1",
+						Name:    "test.example.com",
+						Type:    "A",
+						Content: "1.2.3.4",
+						TTL:     300,
+					},
+				}, nil, nil
+			},
+			updateDNSRecordFunc: func(ctx context.Context, rc *cf.ResourceContainer, params cf.UpdateDNSRecordParams) (cf.DNSRecord, error) {
+				// Verify the update parameters
+				if params.Content != "192.168.1.1" {
+					return cf.DNSRecord{}, fmt.Errorf("expected IP 192.168.1.1, got %s", params.Content)
+				}
+				return cf.DNSRecord{
+					ID:      "rec1",
+					Name:    "test.example.com",
+					Type:    "A",
+					Content: "192.168.1.1",
+					TTL:     300,
+				}, nil
+			},
+			expectError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Note: We can't easily mock the Cloudflare API in the current implementation
+			// This test demonstrates the structure but would require refactoring the
+			// Cloudflare struct to accept an interface for testing
+
+			// For now, we'll test the parts we can test
+			if tt.fqdn == "invalid" {
+				// Test the getZone function directly
+				_, err := getZone(tt.fqdn)
+				if !tt.expectError {
+					t.Errorf("Expected error for invalid FQDN")
+				}
+				if err == nil {
+					t.Errorf("Expected error, got nil")
+				}
 			}
 		})
 	}

--- a/pkg/dyn/dyn_test.go
+++ b/pkg/dyn/dyn_test.go
@@ -1,0 +1,330 @@
+/*
+Copyright © 2024 Francesco Giudici <dev@foggy.day>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dyn
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ddflare/ddflare/pkg/ddman"
+	"github.com/ddflare/ddflare/pkg/version"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+
+	if client == nil {
+		t.Fatal("Expected non-nil client")
+	}
+
+	expectedEndpoint := "https://members.dyndns.org"
+	if client.GetApiEndpoint() != expectedEndpoint {
+		t.Errorf("Expected default endpoint %q, got %q", expectedEndpoint, client.GetApiEndpoint())
+	}
+
+	expectedUserAgent := "ddflare-dynlib-" + version.Version
+	if client.GetUserAgent() != expectedUserAgent {
+		t.Errorf("Expected default user agent %q, got %q", expectedUserAgent, client.GetUserAgent())
+	}
+
+	if client.API != nil {
+		t.Error("Expected API to be nil before initialization")
+	}
+}
+
+func TestNewWithEndpoint(t *testing.T) {
+	t.Parallel()
+
+	customEndpoint := "https://custom.dyn.endpoint.com"
+	client := NewWithEndpoint(customEndpoint)
+
+	if client == nil {
+		t.Fatal("Expected non-nil client")
+	}
+
+	if client.GetApiEndpoint() != customEndpoint {
+		t.Errorf("Expected custom endpoint %q, got %q", customEndpoint, client.GetApiEndpoint())
+	}
+
+	expectedUserAgent := "ddflare-dynlib-" + version.Version
+	if client.GetUserAgent() != expectedUserAgent {
+		t.Errorf("Expected default user agent %q, got %q", expectedUserAgent, client.GetUserAgent())
+	}
+
+	if client.API != nil {
+		t.Error("Expected API to be nil before initialization")
+	}
+}
+
+func TestClient_ImplementsDNSManager(t *testing.T) {
+	t.Parallel()
+
+	var _ ddman.DNSManager = (*Client)(nil)
+}
+
+func TestClient_GetSetApiEndpoint(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+
+	// Test default endpoint
+	defaultEndpoint := client.GetApiEndpoint()
+	if defaultEndpoint == "" {
+		t.Error("Expected non-empty default API endpoint")
+	}
+
+	// Test setting custom endpoint
+	customEndpoint := "https://custom.api.endpoint.com"
+	client.SetApiEndpoint(customEndpoint)
+
+	if got := client.GetApiEndpoint(); got != customEndpoint {
+		t.Errorf("Expected API endpoint %q, got %q", customEndpoint, got)
+	}
+}
+
+func TestClient_GetSetUserAgent(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+
+	// Test default user agent
+	defaultUA := client.GetUserAgent()
+	if defaultUA == "" {
+		t.Error("Expected non-empty default user agent")
+	}
+	if !strings.HasPrefix(defaultUA, "ddflare-dynlib-") {
+		t.Errorf("Expected user agent to start with 'ddflare-dynlib-', got %q", defaultUA)
+	}
+
+	// Test setting custom user agent
+	customUA := "CustomApp/1.0"
+	client.SetUserAgent(customUA)
+
+	if got := client.GetUserAgent(); got != customUA {
+		t.Errorf("Expected user agent %q, got %q", customUA, got)
+	}
+}
+
+func TestClient_Init(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		authToken   string
+		expectError bool
+	}{
+		"valid_token":   {"valid-token-123", false},
+		"empty_token":   {"", false},
+		"another_token": {"user:password", false},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			client := New()
+			err := client.Init(tt.authToken)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				if client.API != nil {
+					t.Error("Expected API to remain nil after failed initialization")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if client.API == nil {
+					t.Error("Expected API to be initialized")
+				}
+			}
+		})
+	}
+}
+
+func TestClient_InitAfterSetEndpoint(t *testing.T) {
+	t.Parallel()
+
+	customEndpoint := "https://custom.dyn.endpoint.com"
+	client := New()
+	client.SetApiEndpoint(customEndpoint)
+
+	err := client.Init("test-token")
+	if err != nil {
+		t.Fatalf("Unexpected error during initialization: %v", err)
+	}
+
+	if client.API == nil {
+		t.Error("Expected API to be initialized")
+	}
+
+	// Verify that the endpoint was used during initialization
+	if client.GetApiEndpoint() != customEndpoint {
+		t.Errorf("Expected endpoint %q to be preserved, got %q", customEndpoint, client.GetApiEndpoint())
+	}
+}
+
+func TestClient_InitAfterSetUserAgent(t *testing.T) {
+	t.Parallel()
+
+	customUA := "TestApp/2.0"
+	client := New()
+	client.SetUserAgent(customUA)
+
+	err := client.Init("test-token")
+	if err != nil {
+		t.Fatalf("Unexpected error during initialization: %v", err)
+	}
+
+	if client.API == nil {
+		t.Error("Expected API to be initialized")
+	}
+
+	// Verify that the user agent was preserved
+	if client.GetUserAgent() != customUA {
+		t.Errorf("Expected user agent %q to be preserved, got %q", customUA, client.GetUserAgent())
+	}
+}
+
+func TestClient_Resolve(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+
+	tests := map[string]struct {
+		fqdn        string
+		expectError bool
+	}{
+		"valid_domain":   {"google.com", false},
+		"localhost":      {"localhost", false},
+		"invalid_domain": {"this-domain-should-not-exist-12345.invalid", true},
+		"empty_domain":   {"", true},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			ip, err := client.Resolve(tt.fqdn)
+
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("Expected error for FQDN %q, but got IP %q", tt.fqdn, ip)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for FQDN %q: %v", tt.fqdn, err)
+				}
+				if ip == "" {
+					t.Errorf("Expected non-empty IP for FQDN %q", tt.fqdn)
+				}
+			}
+		})
+	}
+}
+
+func TestClient_SetEndpointAfterInit(t *testing.T) {
+	t.Parallel()
+
+	client := New()
+
+	// Initialize the client
+	err := client.Init("test-token")
+	if err != nil {
+		t.Fatalf("Failed to initialize client: %v", err)
+	}
+
+	// Set a new endpoint after initialization
+	newEndpoint := "https://new.endpoint.com"
+	client.SetApiEndpoint(newEndpoint)
+
+	// Verify the endpoint was changed
+	if client.GetApiEndpoint() != newEndpoint {
+		t.Errorf("Expected endpoint %q, got %q", newEndpoint, client.GetApiEndpoint())
+	}
+
+	// Note: According to the comment in the code, this change would be
+	// ineffective for the already initialized API, but the getter should
+	// still return the new value
+}
+
+func TestClient_FullWorkflow(t *testing.T) {
+	t.Parallel()
+
+	// Test the complete workflow without actual API calls
+	client := New()
+
+	// 1. Configure client
+	customEndpoint := "https://localhost:8080"
+	customUA := "TestWorkflow/1.0"
+
+	client.SetApiEndpoint(customEndpoint)
+	client.SetUserAgent(customUA)
+
+	// Verify configuration
+	if client.GetApiEndpoint() != customEndpoint {
+		t.Errorf("Expected endpoint %q, got %q", customEndpoint, client.GetApiEndpoint())
+	}
+	if client.GetUserAgent() != customUA {
+		t.Errorf("Expected user agent %q, got %q", customUA, client.GetUserAgent())
+	}
+
+	// 2. Initialize client
+	err := client.Init("test-token")
+	if err != nil {
+		t.Fatalf("Failed to initialize client: %v", err)
+	}
+
+	// 3. Test resolve (this should work with real domains)
+	ip, err := client.Resolve("google.com")
+	if err != nil {
+		t.Errorf("Failed to resolve google.com: %v", err)
+	} else if ip == "" {
+		t.Error("Expected non-empty IP for google.com")
+	}
+
+	// 4. Test update (this will likely fail with test credentials, but tests the flow)
+	err = client.Update("test.example.com", "192.168.1.1")
+	// We don't assert on the error here since it depends on external API
+	// But we can verify the method doesn't panic
+	t.Logf("Update result: %v", err)
+}
+
+func TestDefaultConstants(t *testing.T) {
+	t.Parallel()
+
+	// Test that the default constants are as expected
+	client := New()
+
+	expectedEndpoint := "https://members.dyndns.org"
+	if client.GetApiEndpoint() != expectedEndpoint {
+		t.Errorf("Expected default endpoint %q, got %q", expectedEndpoint, client.GetApiEndpoint())
+	}
+
+	expectedUAPrefix := "ddflare-dynlib-"
+	ua := client.GetUserAgent()
+	if !strings.HasPrefix(ua, expectedUAPrefix) {
+		t.Errorf("Expected user agent to start with %q, got %q", expectedUAPrefix, ua)
+	}
+
+	if !strings.HasSuffix(ua, version.Version) {
+		t.Errorf("Expected user agent to end with version %q, got %q", version.Version, ua)
+	}
+}

--- a/pkg/dyndnsapi/dyndnsapi_test.go
+++ b/pkg/dyndnsapi/dyndnsapi_test.go
@@ -1,0 +1,441 @@
+/*
+Copyright © 2024 Francesco Giudici <dev@foggy.day>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dyndnsapi
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint    string
+		token       string
+		userAgent   string
+		expectError bool
+		errorMsg    string
+	}{
+		"valid_params": {
+			endpoint:    "https://api.example.com",
+			token:       "user:password",
+			userAgent:   "TestApp/1.0",
+			expectError: false,
+		},
+		"empty_endpoint": {
+			endpoint:    "",
+			token:       "user:password",
+			userAgent:   "TestApp/1.0",
+			expectError: true,
+			errorMsg:    "missing endpoint",
+		},
+		"empty_useragent": {
+			endpoint:    "https://api.example.com",
+			token:       "user:password",
+			userAgent:   "",
+			expectError: true,
+			errorMsg:    "missing useragent",
+		},
+		"empty_token_allowed": {
+			endpoint:    "https://api.example.com",
+			token:       "",
+			userAgent:   "TestApp/1.0",
+			expectError: false,
+		},
+		"all_empty_except_endpoint_and_useragent": {
+			endpoint:    "https://api.example.com",
+			token:       "",
+			userAgent:   "TestApp/1.0",
+			expectError: false,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			api, err := New(tt.endpoint, tt.token, tt.userAgent)
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tt.errorMsg, err.Error())
+				}
+				if api != nil {
+					t.Error("Expected API to be nil on error")
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+				if api == nil {
+					t.Error("Expected non-nil API")
+				} else {
+					if api.baseURL != tt.endpoint {
+						t.Errorf("Expected baseURL %q, got %q", tt.endpoint, api.baseURL)
+					}
+					if api.userAgent != tt.userAgent {
+						t.Errorf("Expected userAgent %q, got %q", tt.userAgent, api.userAgent)
+					}
+
+					// Check that token is properly base64 encoded
+					expectedToken := base64.StdEncoding.EncodeToString([]byte(tt.token))
+					if api.apiToken != expectedToken {
+						t.Errorf("Expected encoded token %q, got %q", expectedToken, api.apiToken)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestAPI_Update_WithMockServer(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		responseBody   string
+		responseStatus int
+		expectedCode   ReturnCode
+		expectError    bool
+		errorMsg       string
+	}{
+		"good_response": {
+			responseBody:   "good 192.168.1.1",
+			responseStatus: 200,
+			expectedCode:   MsgGood,
+			expectError:    false,
+		},
+		"nochg_response": {
+			responseBody:   "nochg 192.168.1.1",
+			responseStatus: 200,
+			expectedCode:   MsgNoChg,
+			expectError:    false,
+		},
+		"badauth_response": {
+			responseBody:   "badauth",
+			responseStatus: 200,
+			expectedCode:   MsgBadAuth,
+			expectError:    true,
+			errorMsg:       "bad username or password",
+		},
+		"notdonator_response": {
+			responseBody:   "!donator",
+			responseStatus: 200,
+			expectedCode:   MsgNotDonator,
+			expectError:    true,
+			errorMsg:       "premium option not available",
+		},
+		"notfqdn_response": {
+			responseBody:   "nofqdn",
+			responseStatus: 200,
+			expectedCode:   MsgNotFQDN,
+			expectError:    true,
+			errorMsg:       "invalid FQDN: bad syntax",
+		},
+		"nohost_response": {
+			responseBody:   "nohost",
+			responseStatus: 200,
+			expectedCode:   MsgNoHost,
+			expectError:    true,
+			errorMsg:       "invalid FQDN: hostname does not exist",
+		},
+		"numhost_response": {
+			responseBody:   "numhost",
+			responseStatus: 200,
+			expectedCode:   MsgNumHost,
+			expectError:    true,
+			errorMsg:       "round robin update detected",
+		},
+		"abuse_response": {
+			responseBody:   "abuse",
+			responseStatus: 200,
+			expectedCode:   MsgAbuse,
+			expectError:    true,
+			errorMsg:       "FQDN blocked for update abuse",
+		},
+		"badagent_response": {
+			responseBody:   "badagent",
+			responseStatus: 200,
+			expectedCode:   MsgBadAgent,
+			expectError:    true,
+			errorMsg:       "invalid user agent",
+		},
+		"dnserr_response": {
+			responseBody:   "dnserr",
+			responseStatus: 200,
+			expectedCode:   MsgDNSErr,
+			expectError:    true,
+			errorMsg:       "server unavailable: DNS error",
+		},
+		"911_response": {
+			responseBody:   "911",
+			responseStatus: 200,
+			expectedCode:   Msg911,
+			expectError:    true,
+			errorMsg:       "server unavailable: generic error",
+		},
+		"unknown_response": {
+			responseBody:   "unknown_status",
+			responseStatus: 200,
+			expectedCode:   MsgUnknownErr,
+			expectError:    true,
+			errorMsg:       "protocol error: unknown reply message",
+		},
+		"http_error": {
+			responseBody:   "",
+			responseStatus: 500,
+			expectedCode:   MsgCommErr,
+			expectError:    true,
+			errorMsg:       "returned 500",
+		},
+		"empty_response": {
+			responseBody:   "",
+			responseStatus: 200,
+			expectedCode:   MsgCommErr,
+			expectError:    true,
+			errorMsg:       "failure reading endpoint",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			// Create mock server
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Verify the request
+				if r.Method != "GET" {
+					t.Errorf("Expected GET request, got %s", r.Method)
+				}
+				if r.URL.Path != "/nic/update" {
+					t.Errorf("Expected path /nic/update, got %s", r.URL.Path)
+				}
+
+				// Check query parameters
+				hostname := r.URL.Query().Get("hostname")
+				if hostname != "test.example.com" {
+					t.Errorf("Expected hostname test.example.com, got %s", hostname)
+				}
+				myip := r.URL.Query().Get("myip")
+				if myip != "192.168.1.1" {
+					t.Errorf("Expected myip 192.168.1.1, got %s", myip)
+				}
+
+				// Check headers
+				auth := r.Header.Get("Authorization")
+				if !strings.HasPrefix(auth, "Basic ") {
+					t.Errorf("Expected Basic auth header, got %s", auth)
+				}
+				ua := r.Header.Get("User-Agent")
+				if ua != "TestApp/1.0" {
+					t.Errorf("Expected User-Agent TestApp/1.0, got %s", ua)
+				}
+
+				w.WriteHeader(tt.responseStatus)
+				if tt.responseBody != "" {
+					w.Write([]byte(tt.responseBody))
+				}
+			}))
+			defer server.Close()
+
+			// Create API with mock server endpoint
+			api, err := New(server.URL, "user:password", "TestApp/1.0")
+			if err != nil {
+				t.Fatalf("Failed to create API instance: %v", err)
+			}
+
+			code, err := api.Update("test.example.com", "192.168.1.1")
+
+			if code != tt.expectedCode {
+				t.Errorf("Expected return code %d, got %d", tt.expectedCode, code)
+			}
+
+			if tt.expectError {
+				if err == nil {
+					t.Error("Expected error but got none")
+				}
+				if tt.errorMsg != "" && !strings.Contains(err.Error(), tt.errorMsg) {
+					t.Errorf("Expected error to contain %q, got %q", tt.errorMsg, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestInterpretResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		response     string
+		expectedCode ReturnCode
+	}{
+		"good":            {"good", MsgGood},
+		"good_with_ip":    {"good 192.168.1.1", MsgGood},
+		"nochg":           {"nochg", MsgNoChg},
+		"nochg_with_ip":   {"nochg 192.168.1.1", MsgNoChg},
+		"badauth":         {"badauth", MsgBadAuth},
+		"notdonator":      {"!donator", MsgNotDonator},
+		"notfqdn":         {"nofqdn", MsgNotFQDN},
+		"nohost":          {"nohost", MsgNoHost},
+		"numhost":         {"numhost", MsgNumHost},
+		"abuse":           {"abuse", MsgAbuse},
+		"badagent":        {"badagent", MsgBadAgent},
+		"dnserr":          {"dnserr", MsgDNSErr},
+		"911":             {"911", Msg911},
+		"unknown":         {"unknown_status", MsgUnknownErr},
+		"empty":           {"", MsgUnknownErr},
+		"multiple_fields": {"good 192.168.1.1 extra_field", MsgGood},
+		"whitespace":      {"  good  192.168.1.1  ", MsgGood},
+		"case_sensitive":  {"Good", MsgUnknownErr}, // Should be case sensitive
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			code := interpretResponse(tt.response)
+
+			if code != tt.expectedCode {
+				t.Errorf("Expected return code %d for response %q, got %d", tt.expectedCode, tt.response, code)
+			}
+		})
+	}
+}
+
+func TestReturnCodeConstants(t *testing.T) {
+	t.Parallel()
+
+	// Test that all return codes have corresponding messages
+	expectedCodes := []ReturnCode{
+		MsgGood, MsgNoChg, MsgBadAuth, MsgNotDonator, MsgNotFQDN,
+		MsgNoHost, MsgNumHost, MsgAbuse, MsgBadAgent, MsgDNSErr,
+		Msg911, MsgUnknownErr,
+	}
+
+	for _, code := range expectedCodes {
+		if msg, exists := code2Msg[int(code)]; !exists {
+			t.Errorf("Return code %d does not have a corresponding message", code)
+		} else if msg == "" {
+			t.Errorf("Return code %d has an empty message", code)
+		}
+	}
+
+	// Test that MsgLast is greater than all other codes
+	for _, code := range expectedCodes {
+		if code >= MsgLast {
+			t.Errorf("Return code %d should be less than MsgLast (%d)", code, MsgLast)
+		}
+	}
+}
+
+func TestCode2MsgMapping(t *testing.T) {
+	t.Parallel()
+
+	expectedMappings := map[int]string{
+		MsgGood:       "the update was successful",
+		MsgNoChg:      "the update changed no settings",
+		MsgBadAuth:    "bad username or password",
+		MsgNotDonator: "premium option not available for this account",
+		MsgNotFQDN:    "invalid FQDN: bad syntax",
+		MsgNoHost:     "invalid FQDN: hostname does not exist",
+		MsgNumHost:    "round robin update detected",
+		MsgAbuse:      "FQDN blocked for update abuse",
+		MsgBadAgent:   "invalid user agent",
+		MsgDNSErr:     "server unavailable: DNS error",
+		Msg911:        "server unavailable: generic error",
+		MsgUnknownErr: "protocol error: unknown reply message",
+	}
+
+	for code, expectedMsg := range expectedMappings {
+		if msg, exists := code2Msg[code]; !exists {
+			t.Errorf("Expected message for code %d not found", code)
+		} else if msg != expectedMsg {
+			t.Errorf("Expected message %q for code %d, got %q", expectedMsg, code, msg)
+		}
+	}
+}
+
+func TestAPI_Update_AuthHeaderEncoding(t *testing.T) {
+	t.Parallel()
+
+	// Test that the authorization header is properly base64 encoded
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Basic ") {
+			t.Errorf("Expected Basic auth, got %s", auth)
+			return
+		}
+
+		// Decode the base64 part
+		encoded := strings.TrimPrefix(auth, "Basic ")
+		decoded, err := base64.StdEncoding.DecodeString(encoded)
+		if err != nil {
+			t.Errorf("Failed to decode auth header: %v", err)
+			return
+		}
+
+		if string(decoded) != "testuser:testpass" {
+			t.Errorf("Expected decoded auth 'testuser:testpass', got %q", string(decoded))
+		}
+
+		w.WriteHeader(200)
+		w.Write([]byte("good 192.168.1.1"))
+	}))
+	defer server.Close()
+
+	api, err := New(server.URL, "testuser:testpass", "TestApp/1.0")
+	if err != nil {
+		t.Fatalf("Failed to create API instance: %v", err)
+	}
+
+	_, err = api.Update("test.example.com", "192.168.1.1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}
+
+func TestAPI_Update_ConnectionError(t *testing.T) {
+	t.Parallel()
+
+	// Test with invalid endpoint that should cause connection error
+	api, err := New("http://invalid-endpoint-that-should-not-exist.local:9999", "user:pass", "TestApp/1.0")
+	if err != nil {
+		t.Fatalf("Failed to create API instance: %v", err)
+	}
+
+	code, err := api.Update("test.example.com", "192.168.1.1")
+
+	if code != MsgCommErr {
+		t.Errorf("Expected return code %d, got %d", MsgCommErr, code)
+	}
+	if err == nil {
+		t.Error("Expected connection error but got none")
+	}
+	if !strings.Contains(err.Error(), "connection to") {
+		t.Errorf("Expected connection error message, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
Improve test coverage, used help from Github Copilot.
It did quite a good job for the boring tests, of course the critical part was to test the Updates to the actual dyndns providers (there I had to manually remove the tests that were trying to connect to the API of real services to test for errors... would not be kind to dyndns providers 😁 ).
Copilot anyway surprised me writing a simple mock function using httptest for the dyndnsapi update. Was simple, but still one step further than the boring setter/getter tests.
For the Update tests, the idea is to write a replacement lib for a test server implementing the dyndns API.
That could be fun... or not that much, still in the TODO list, maybe one boring day... 😆 
